### PR TITLE
LoggingFactory for containerized processes

### DIFF
--- a/src/LoggingFactory.php
+++ b/src/LoggingFactory.php
@@ -11,6 +11,7 @@ use Psr\Log\LogLevel;
 
 final class LoggingFactory
 {
+    const STDERR = 'php://stderr';
     private $filesPath;
     private $loggingChannel;
     private $level;
@@ -22,7 +23,7 @@ final class LoggingFactory
         $this->level = $level;
     }
 
-    public static function containerized($loggingChannel = 'default', string $level = LogLevel::DEBUG)
+    public static function stderr($loggingChannel = 'default', string $level = LogLevel::DEBUG)
     {
         return new self(null, $loggingChannel, $level);
     }
@@ -44,7 +45,7 @@ final class LoggingFactory
             $stream->setFormatter($detailedFormatter);
             $logger->pushHandler($stream);
         } else {
-            $stream = new StreamHandler('php://stderr', $this->level);
+            $stream = new StreamHandler(self::STDERR, $this->level);
             $stream->pushProcessor(new ProcessIdProcessor());
             $detailedFormatter = new JsonFormatter();
             $detailedFormatter->includeStacktraces();

--- a/src/LoggingFactory.php
+++ b/src/LoggingFactory.php
@@ -15,28 +15,42 @@ final class LoggingFactory
     private $loggingChannel;
     private $level;
 
-    public function __construct(string $filesPath, string $loggingChannel = 'default', string $level = LogLevel::DEBUG)
+    public function __construct(string $filesPath = null, string $loggingChannel = 'default', string $level = LogLevel::DEBUG)
     {
         $this->filesPath = rtrim($filesPath, '/');
         $this->loggingChannel = $loggingChannel;
         $this->level = $level;
     }
 
+    public static function containerized($loggingChannel = 'default', string $level = LogLevel::DEBUG)
+    {
+        return new self(null, $loggingChannel, $level);
+    }
+
     public function logger() : LoggerInterface
     {
         $logger = new Logger($this->loggingChannel);
 
-        $stream = new StreamHandler($this->filesPath.'/all.json', $this->level);
-        $stream->pushProcessor(new ProcessIdProcessor());
-        $stream->setFormatter(new JsonFormatter());
-        $logger->pushHandler($stream);
+        if ($this->filesPath) {
+            $stream = new StreamHandler($this->filesPath.'/all.json', $this->level);
+            $stream->pushProcessor(new ProcessIdProcessor());
+            $stream->setFormatter(new JsonFormatter());
+            $logger->pushHandler($stream);
 
-        $stream = new StreamHandler($this->filesPath.'/error.json', LogLevel::ERROR);
-        $stream->pushProcessor(new ProcessIdProcessor());
-        $detailedFormatter = new JsonFormatter();
-        $detailedFormatter->includeStacktraces();
-        $stream->setFormatter($detailedFormatter);
-        $logger->pushHandler($stream);
+            $stream = new StreamHandler($this->filesPath.'/error.json', LogLevel::ERROR);
+            $stream->pushProcessor(new ProcessIdProcessor());
+            $detailedFormatter = new JsonFormatter();
+            $detailedFormatter->includeStacktraces();
+            $stream->setFormatter($detailedFormatter);
+            $logger->pushHandler($stream);
+        } else {
+            $stream = new StreamHandler('php://stderr', $this->level);
+            $stream->pushProcessor(new ProcessIdProcessor());
+            $detailedFormatter = new JsonFormatter();
+            $detailedFormatter->includeStacktraces();
+            $stream->setFormatter($detailedFormatter);
+            $logger->pushHandler($stream);
+        }
 
         return $logger;
     }

--- a/test/LoggingFactoryTest.php
+++ b/test/LoggingFactoryTest.php
@@ -18,4 +18,14 @@ final class LoggingFactoryTest extends TestCase
         $logger = $factory->logger();
         $this->assertInstanceOf(LoggerInterface::class, $logger);
     }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_logger_for_containerized_processes()
+    {
+        $factory = LoggingFactory::containerized('my-application', LogLevel::INFO);
+        $logger = $factory->logger();
+        $this->assertInstanceOf(LoggerInterface::class, $logger);
+    }
 }

--- a/test/LoggingFactoryTest.php
+++ b/test/LoggingFactoryTest.php
@@ -24,7 +24,7 @@ final class LoggingFactoryTest extends TestCase
      */
     public function it_creates_a_logger_for_containerized_processes()
     {
-        $factory = LoggingFactory::containerized('my-application', LogLevel::INFO);
+        $factory = LoggingFactory::stderr('my-application', LogLevel::INFO);
         $logger = $factory->logger();
         $this->assertInstanceOf(LoggerInterface::class, $logger);
     }


### PR DESCRIPTION
The standard practice is to write all logs to stderr and let the container runtime or orchestrator direct these logs where needed.

If they were to be written on files inside the container, they would be deleted with the container itself.

The name of the method has been abstracted from the fact that it runs inside a container, as it can be in general useful to log on `stderr` rather than on files.